### PR TITLE
Modify Java example to use Google Cloud OTLP endpoint

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -45,6 +45,12 @@
 		    <groupId>com.google.genai</groupId>
 		    <artifactId>google-genai</artifactId>
 		    <version>1.8.0</version>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
         <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>
@@ -54,11 +60,6 @@
             <groupId>com.google.cloud.opentelemetry</groupId>
             <artifactId>exporter-auto</artifactId>
             <version>0.36.0-alpha</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.cloud.opentelemetry</groupId>
-            <artifactId>exporter-trace</artifactId>
-            <version>0.36.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud.opentelemetry</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -34,7 +34,7 @@
             <dependency>
                 <groupId>io.opentelemetry.instrumentation</groupId>
                 <artifactId>opentelemetry-instrumentation-bom</artifactId>
-                <version>2.12.0</version>
+                <version>2.15.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -53,17 +53,17 @@
         <dependency>
             <groupId>com.google.cloud.opentelemetry</groupId>
             <artifactId>exporter-auto</artifactId>
-            <version>0.33.0-alpha</version>
+            <version>0.36.0-alpha</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud.opentelemetry</groupId>
             <artifactId>exporter-trace</artifactId>
-            <version>0.33.0</version>
+            <version>0.36.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud.opentelemetry</groupId>
             <artifactId>exporter-metrics</artifactId>
-            <version>0.33.0</version>
+            <version>0.36.0</version>
         </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/java/src/main/java/com/example/demo/DemoApplication.java
+++ b/java/src/main/java/com/example/demo/DemoApplication.java
@@ -19,8 +19,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.google.cloud.ServiceOptions;
-import com.google.cloud.MetadataConfig;
 import com.google.genai.Client;
 
 @SpringBootApplication
@@ -36,7 +34,6 @@ public class DemoApplication {
 
 @RestController
 class HelloController {
-    private final String projectId = ServiceOptions.getDefaultProjectId();
     private Client vertexAI;
     private String model;
     private final Logger LOGGER = LoggerFactory.getLogger(HelloController.class);
@@ -54,8 +51,8 @@ class HelloController {
     @PostConstruct
     public void init() {
         vertexAI = Client.builder()
-                .project(projectId)
-                .location(getRegion())
+                .project(Metadata.projectId())
+                .location(Metadata.region())
                 .vertexAI(true)
                 .build();
         model = System.getenv().getOrDefault("MODEL_NAME", "gemini-2.5-flash");
@@ -77,17 +74,5 @@ class HelloController {
                 .log("Content is generated");
         counter.add(1, LANGUAGE_ATTR);
         return response.text();
-    }
-
-    private String getRegion() {
-        var region = MetadataConfig.getAttribute("instance/region");
-        if (region == null) {
-            return "us-west1";
-        }
-        int idx = region.lastIndexOf("/");
-        if (idx >= 0) {
-            return region.substring(idx + 1);
-        }
-        return region;
     }
 }

--- a/java/src/main/java/com/example/demo/LoggingEventGoogleCloudEncoder.java
+++ b/java/src/main/java/com/example/demo/LoggingEventGoogleCloudEncoder.java
@@ -30,8 +30,7 @@ public class LoggingEventGoogleCloudEncoder extends EncoderBase<ILoggingEvent> {
     private final String projectId;
     private final String tracePrefix;
 
-    // need custom adapter to serialize java.util.Optional values used in
-    // com.google.genai
+    // custom adapter to serialize java.util.Optional values
     static class OptionalAdapter implements JsonSerializer<Optional<?>>, JsonDeserializer<Optional<?>> {
         @Override
         public JsonElement serialize(Optional<?> src, Type typeOfSrc, JsonSerializationContext context) {
@@ -47,7 +46,24 @@ public class LoggingEventGoogleCloudEncoder extends EncoderBase<ILoggingEvent> {
         @Override
         public Optional<?> deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
                 throws JsonParseException {
-            // TODO Auto-generated method stub
+            throw new UnsupportedOperationException("Unimplemented method 'deserialize'");
+        }
+    }
+
+    // custom adapter to serialize java.time.Instant values
+    static class InstantAdapter implements JsonSerializer<Instant>, JsonDeserializer<Instant> {
+        @Override
+        public JsonElement serialize(Instant src, Type typeOfSrc, JsonSerializationContext context) {
+            if (src != null) {
+                return context.serialize(src.toString());
+            } else {
+                return context.serialize(null);
+            }
+        }
+
+        @Override
+        public Instant deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+                throws JsonParseException {
             throw new UnsupportedOperationException("Unimplemented method 'deserialize'");
         }
     }
@@ -55,6 +71,7 @@ public class LoggingEventGoogleCloudEncoder extends EncoderBase<ILoggingEvent> {
     public LoggingEventGoogleCloudEncoder() {
         this.gson = new GsonBuilder()
                 .registerTypeAdapter(Optional.class, new OptionalAdapter())
+                .registerTypeAdapter(Instant.class, new InstantAdapter())
                 .create();
         this.projectId = ServiceOptions.getDefaultProjectId();
         this.tracePrefix = "projects/" + (projectId == null ? "" : projectId) + "/traces/";

--- a/java/src/main/java/com/example/demo/LoggingEventGoogleCloudEncoder.java
+++ b/java/src/main/java/com/example/demo/LoggingEventGoogleCloudEncoder.java
@@ -7,23 +7,55 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 
 import com.google.cloud.ServiceOptions;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
 
+import java.lang.reflect.Type;
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.Optional;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
 
-
-public class LoggingEventGoogleCloudEncoder extends EncoderBase<ILoggingEvent>  {
+public class LoggingEventGoogleCloudEncoder extends EncoderBase<ILoggingEvent> {
     private static final byte[] EMPTY_BYTES = new byte[0];
     private final Gson gson;
     private final String projectId;
     private final String tracePrefix;
 
+    // need custom adapter to serialize java.util.Optional values used in
+    // com.google.genai
+    static class OptionalAdapter implements JsonSerializer<Optional<?>>, JsonDeserializer<Optional<?>> {
+        @Override
+        public JsonElement serialize(Optional<?> src, Type typeOfSrc, JsonSerializationContext context) {
+            // If the Optional contains a value, serialize the value itself
+            if (src.isPresent()) {
+                return context.serialize(src.get());
+            } else {
+                // If the Optional is empty, serialize as null
+                return context.serialize(null);
+            }
+        }
+
+        @Override
+        public Optional<?> deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+                throws JsonParseException {
+            // TODO Auto-generated method stub
+            throw new UnsupportedOperationException("Unimplemented method 'deserialize'");
+        }
+    }
+
     public LoggingEventGoogleCloudEncoder() {
-        this.gson = new Gson();
+        this.gson = new GsonBuilder()
+                .registerTypeAdapter(Optional.class, new OptionalAdapter())
+                .create();
         this.projectId = ServiceOptions.getDefaultProjectId();
         this.tracePrefix = "projects/" + (projectId == null ? "" : projectId) + "/traces/";
     }
@@ -65,17 +97,17 @@ public class LoggingEventGoogleCloudEncoder extends EncoderBase<ILoggingEvent>  
     private static String severityFor(Level level) {
         switch (level.toInt()) {
             case Level.TRACE_INT:
-            return "DEBUG";
+                return "DEBUG";
             case Level.DEBUG_INT:
-            return "DEBUG";
+                return "DEBUG";
             case Level.INFO_INT:
-            return "INFO";
+                return "INFO";
             case Level.WARN_INT:
-            return "WARNING";
+                return "WARNING";
             case Level.ERROR_INT:
-            return "ERROR";
+                return "ERROR";
             default:
-            return "DEFAULT";
+                return "DEFAULT";
         }
     }
 }

--- a/java/src/main/java/com/example/demo/Metadata.java
+++ b/java/src/main/java/com/example/demo/Metadata.java
@@ -1,0 +1,32 @@
+package com.example.demo;
+
+import com.google.api.client.util.Strings;
+import com.google.cloud.MetadataConfig;
+
+public class Metadata {
+
+    private static String projectId, region;
+
+    public static String projectId() {
+        if (!Strings.isNullOrEmpty(projectId)) {
+            return projectId;
+        }
+        projectId = MetadataConfig.getProjectId();
+        return projectId;
+    }
+
+    public static String region() {
+        if (!Strings.isNullOrEmpty(region)) {
+            return region;
+        }
+        region = MetadataConfig.getAttribute("instance/region");
+        if (region == null) {
+            region = "us-west1";
+        }
+        int idx = region.lastIndexOf("/");
+        if (idx >= 0) {
+            region = region.substring(idx + 1);
+        }
+        return region;
+    }
+}

--- a/java/src/main/java/com/example/demo/OpenTelemetryCustomizedConfigurationProvider.java
+++ b/java/src/main/java/com/example/demo/OpenTelemetryCustomizedConfigurationProvider.java
@@ -1,0 +1,87 @@
+package com.example.demo;
+
+import com.google.auth.oauth2.GoogleCredentials;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
+import io.opentelemetry.semconv.ServiceAttributes;
+
+import org.springframework.context.annotation.Configuration;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@Configuration
+public class OpenTelemetryCustomizedConfigurationProvider
+    implements AutoConfigurationCustomizerProvider {
+
+  @Override
+  public void customize(AutoConfigurationCustomizer autoConfiguration) {
+    autoConfiguration
+        .addResourceCustomizer(this::setupGoogleProject)
+        .addTracerProviderCustomizer(this::configureSdkTracerProvider);
+  }
+
+  private SdkTracerProviderBuilder configureSdkTracerProvider(
+      SdkTracerProviderBuilder tracerProvider, ConfigProperties config) {
+    GoogleCredentials credentials;
+    try {
+      credentials = GoogleCredentials.getApplicationDefault();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    var otlpGrpcSpanExporter = OtlpGrpcSpanExporter.builder()
+        .setHeaders(
+            () -> {
+              Map<String, List<String>> gcpHeaders;
+              try {
+                credentials.refreshIfExpired();
+                gcpHeaders = credentials.getRequestMetadata();
+              } catch (IOException e) {
+                // Handle authentication error
+                throw new RuntimeException(e);
+              }
+              Map<String, String> flattenedHeaders = gcpHeaders.entrySet().stream()
+                  .collect(
+                      Collectors.toMap(
+                          Map.Entry::getKey,
+                          entry -> entry.getValue().stream()
+                              .filter(Objects::nonNull)
+                              .filter(s -> !s.isEmpty())
+                              .collect(Collectors.joining(",")),
+                          (v1, v2) -> v2));
+              return flattenedHeaders;
+            })
+        .setTimeout(2, TimeUnit.SECONDS)
+        // NOTE: endpoint URI has to be in HTTP format
+        .setEndpoint("https://telemetry.googleapis.com")
+        .build();
+    return tracerProvider
+        .setSampler(Sampler.alwaysOn())
+        .addSpanProcessor(
+            BatchSpanProcessor.builder(otlpGrpcSpanExporter)
+                .setScheduleDelay(100, TimeUnit.MILLISECONDS)
+                .build());
+  }
+
+  private Resource setupGoogleProject(Resource originalResource, ConfigProperties config) {
+    var serviceName = System.getenv().getOrDefault("K_SERVICE", "java-o11y-demo-app");
+    var resource = Resource.create(
+        Attributes.builder()
+            .put("gcp.project_id", Metadata.projectId())
+            .put(ServiceAttributes.SERVICE_NAME, serviceName)
+            .build());
+    return originalResource.merge(resource);
+  }
+}

--- a/java/src/main/resources/application.properties
+++ b/java/src/main/resources/application.properties
@@ -1,6 +1,4 @@
 spring.application.name=demo
 otel.logs.exporter=none
-otel.traces.exporter=google_cloud_trace,console
 otel.metrics.exporter=google_cloud_monitoring
-otel.resource.attributes.service.name=o11y-demo-java
-otel.traces.sampler=always_on
+otel.java.global-autoconfigure.enabled=true


### PR DESCRIPTION
* Modify configuration of OpenTelemetry to enable it to auto-configure OTLP trace exporter over grpc to use Google Cloud authentication, endpoint and custom attribute (`gcp.project_id`)
* Refactor code to use a new `com.google.genai` library to work with Google's GenAI instead of deprecated com.google.cloud.vertexai
* Modify logback extender to correctly serialize the response from the new genai library
* Upgrade Java runtime to 21

> [!Note]
> This code implements acquiring Google Cloud credentials in code.
> There is also an option to use OpenTelemetry authenticator extension to do the same work